### PR TITLE
Fix first benchmark image to use raw values instead of floor division

### DIFF
--- a/rust/out.py
+++ b/rust/out.py
@@ -132,19 +132,18 @@ def print_results_markdown():
 # Plots
 # ─────────────────────────────────────────────────────────────────────────────
 def bench1():
-    """Horizontal bars – scaled (divide by 10 000 000)."""
-    scale = lambda arr: [max(1, x // 10_000_000) for x in arr]
+    """Horizontal bars – raw values (pixel scale)."""
     y, w  = np.arange(len(ordered_ops)), 0.1
     fig, ax = plt.subplots(figsize=(12, 8))
 
-    ax.barh(y - 2*w, scale(du_volatile_arr),   w, label='Doublets United Volatile',   color='salmon')
-    ax.barh(y -   w, scale(du_nonvolatile_arr),w, label='Doublets United NonVolatile',color='red')
-    ax.barh(y      , scale(ds_volatile_arr),    w, label='Doublets Split Volatile',    color='lightgreen')
-    ax.barh(y +   w, scale(ds_nonvolatile_arr), w, label='Doublets Split NonVolatile', color='green')
-    ax.barh(y + 2*w, scale(neo4j_non_arr),      w, label='Neo4j NonTransaction',       color='lightblue')
-    ax.barh(y + 3*w, scale(neo4j_trans_arr),    w, label='Neo4j Transaction',          color='blue')
+    ax.barh(y - 2*w, du_volatile_arr,   w, label='Doublets United Volatile',   color='salmon')
+    ax.barh(y -   w, du_nonvolatile_arr,w, label='Doublets United NonVolatile',color='red')
+    ax.barh(y      , ds_volatile_arr,    w, label='Doublets Split Volatile',    color='lightgreen')
+    ax.barh(y +   w, ds_nonvolatile_arr, w, label='Doublets Split NonVolatile', color='green')
+    ax.barh(y + 2*w, neo4j_non_arr,      w, label='Neo4j NonTransaction',       color='lightblue')
+    ax.barh(y + 3*w, neo4j_trans_arr,    w, label='Neo4j Transaction',          color='blue')
 
-    ax.set_xlabel('Time (ns) – scaled')
+    ax.set_xlabel('Time (ns)')
     ax.set_title ('Benchmark Comparison: Neo4j vs Doublets (Rust)')
     ax.set_yticks(y); ax.set_yticklabels(ordered_ops); ax.legend()
     fig.tight_layout(); plt.savefig("bench_rust.png"); plt.close(fig)


### PR DESCRIPTION
## Summary

The first benchmark image (`bench_rust.png`) was showing all bars at nearly the same length because the scaling function was using floor division by 10,000,000 with `max(1, ...)`.

**Root cause:** The `bench1()` function in `rust/out.py` used:
```python
scale = lambda arr: [max(1, x // 10_000_000) for x in arr]
```

This caused:
- All Doublets values (~71-1465 ns) to become 0, then clamped to 1
- Most Neo4j values (~900K-52M ns) to become 1-5
- All bars appeared nearly identical, losing meaningful differentiation

**Fix:** Changed to use raw values directly (like `bench2()` but without log scale):
```python
ax.barh(y - 2*w, du_volatile_arr,   w, label='Doublets United Volatile',   color='salmon')
...
```

This:
- Shows actual time differences between operations
- Neo4j bars correctly vary based on their actual times
- Doublets bars are minimal at this scale (as expected per README: "for doublets just minimum value is shown, otherwise it will be not present on the graph")

Fixes #7

## Test plan

- [x] Verified out.py runs without errors
- [x] Generated test images locally with sample benchmark data
- [x] Confirmed new images show meaningful bar length differences (Neo4j bars vary by operation type)
- [ ] CI workflow passes (runs benchmark and generates new images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)